### PR TITLE
feat: add AnyAsyncThrowingSequece, to differentiate from regular one

### DIFF
--- a/Sources/AnyAsyncSequence/AnyAsyncSequence.swift
+++ b/Sources/AnyAsyncSequence/AnyAsyncSequence.swift
@@ -27,8 +27,10 @@ import Foundation
 
 /// A type erased `AsyncSequence`
 ///
-/// This type allows you to create APIs that return an `AsyncSequence` that allows consumers to iterate over the sequence, without exposing the sequence's underlyin type.
-/// Typically, you wouldn't actually initialize this type yourself, but instead create one using the `.eraseToAnyAsyncSequence()` operator also provided with this package.
+/// This type allows you to create APIs that return an `AsyncSequence` that allows consumers to iterate over the
+/// sequence, without exposing the sequence's underlying type.
+/// Typically, you wouldn't actually initialize this type yourself, but instead create one using the
+/// `.eraseToAnyAsyncSequence()` operator also provided with this package.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AnyAsyncSequence<Element>: AsyncSequence {
 
@@ -66,5 +68,4 @@ public struct AnyAsyncSequence<Element>: AsyncSequence {
     }
 
     private let makeAsyncIteratorClosure: () -> AsyncIterator
-
 }

--- a/Sources/AnyAsyncSequence/AsyncSequence+AnySequence.swift
+++ b/Sources/AnyAsyncSequence/AsyncSequence+AnySequence.swift
@@ -34,4 +34,9 @@ public extension AsyncSequence {
         AnyAsyncSequence(self)
     }
 
+    /// Create a type erased version of this sequence
+    /// - Returns: The sequence, wrapped in an `AnyAsyncThrowingSequence`
+    func eraseToAnyAsyncThrowingSequence() -> AnyAsyncThrowingSequence<Element> where {
+        AnyAsyncThrowingSequence(self)
+    }
 }


### PR DESCRIPTION
This makes things easier when dealing with infinite sequences (like values from a Combine Publisher)